### PR TITLE
chore(gh-dash): reorganize PR sections and add dotfiles repo path

### DIFF
--- a/.config/gh-dash/config.yml
+++ b/.config/gh-dash/config.yml
@@ -3,18 +3,14 @@
 prSections:
   - title: Review Requested
     filters: is:open review-requested:@me
-  - title: Tower
-    filters: is:open label:tower
-  - title: Nectar
-    filters: is:open label:nectar
-  - title: Ready to Merge
-    filters: is:open review:approved status:success -label:wip,do-not-merge
+  - title: Recently Updated
+    filters: is:open sort:updated-desc
+  - title: Tower & Nectar
+    filters: is:open label:tower,nectar
   - title: My Pull Requests
     filters: is:open author:@me
   - title: Assigned to Me
     filters: is:open assignee:@me
-  - title: Recently Updated
-    filters: is:open sort:updated-desc
 
 issuesSections:
   - title: My Issues
@@ -32,6 +28,7 @@ defaults:
 
 repoPaths:
   DistylAI/distillery: /Volumes/git/distillery
+  davidsroth/dotfiles: /Users/davidsroth/dotfiles
 
 keybindings:
   universal:


### PR DESCRIPTION
## Summary
- Combined Tower and Nectar sections into single "Tower & Nectar" section for cleaner organization
- Removed "Ready to Merge" section 
- Moved "Recently Updated" section higher in the list for better visibility
- Added dotfiles repository to repoPaths configuration

## Changes
- Merged two separate label filters (`label:tower` and `label:nectar`) into one combined filter (`label:tower,nectar`)
- Reordered PR sections for improved workflow
- Added local dotfiles repo path for easier navigation

🤖 Generated with [Claude Code](https://claude.ai/code)